### PR TITLE
chore: add extra platform in build-platforms array

### DIFF
--- a/.tekton/konflux-app-example-abc01-pull-request.yaml
+++ b/.tekton/konflux-app-example-abc01-pull-request.yaml
@@ -30,6 +30,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:

--- a/.tekton/konflux-app-example-abc01-push.yaml
+++ b/.tekton/konflux-app-example-abc01-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:


### PR DESCRIPTION
Add "linux/arm64" platform in the build-platforms array.